### PR TITLE
Resolve circular dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.1.0.RELEASE</version>
+            <version>2.6.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.11.0</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/cmlteam/web/AppConfiguration.java
+++ b/src/main/java/com/cmlteam/web/AppConfiguration.java
@@ -1,0 +1,22 @@
+package com.cmlteam.web;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.cmlteam.web.LogRestRequestWebInterceptorConfiguration.LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED;
+
+@Configuration
+@ConditionalOnProperty(value = LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED)
+public class AppConfiguration {
+
+  @Bean
+  public LogRestRequestFilter logRestRequestFilter() {
+    return new LogRestRequestFilter();
+  }
+
+  @Bean
+  LogRestRequestWebInterceptor logRestRequestWebInterceptor() {
+    return new LogRestRequestWebInterceptor();
+  }
+}

--- a/src/main/java/com/cmlteam/web/AppConfiguration.java
+++ b/src/main/java/com/cmlteam/web/AppConfiguration.java
@@ -16,7 +16,7 @@ public class AppConfiguration {
   }
 
   @Bean
-  LogRestRequestWebInterceptor logRestRequestWebInterceptor() {
+  public LogRestRequestWebInterceptor logRestRequestWebInterceptor() {
     return new LogRestRequestWebInterceptor();
   }
 }

--- a/src/main/java/com/cmlteam/web/LogRestRequestWebInterceptor.java
+++ b/src/main/java/com/cmlteam/web/LogRestRequestWebInterceptor.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartRequest;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.util.WebUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -14,7 +14,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 /** We need to use interceptor since in plain web Filter the MultipartRequest is not parsed yet */
-public class LogRestRequestWebInterceptor extends HandlerInterceptorAdapter {
+public class LogRestRequestWebInterceptor implements AsyncHandlerInterceptor {
   private static final int TRIM_AFTER = 20000;
   private static Logger log = LoggerFactory.getLogger(LogRestRequestWebInterceptor.class);
 
@@ -62,7 +62,7 @@ public class LogRestRequestWebInterceptor extends HandlerInterceptorAdapter {
       }
       log.info(sb.toString());
     }
-    return super.preHandle(request, response, handler);
+    return true;
   }
 
   private String prepareBodyStr(String body) {

--- a/src/main/java/com/cmlteam/web/LogRestRequestWebInterceptorConfiguration.java
+++ b/src/main/java/com/cmlteam/web/LogRestRequestWebInterceptorConfiguration.java
@@ -3,12 +3,14 @@ package com.cmlteam.web;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import static com.cmlteam.web.LogRestRequestWebInterceptorConfiguration.LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED;
 
 @Configuration
+@Import(AppConfiguration.class)
 @ConditionalOnProperty(value = LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED)
 public class LogRestRequestWebInterceptorConfiguration implements WebMvcConfigurer {
 

--- a/src/main/java/com/cmlteam/web/LogRestRequestWebInterceptorConfiguration.java
+++ b/src/main/java/com/cmlteam/web/LogRestRequestWebInterceptorConfiguration.java
@@ -2,16 +2,15 @@ package com.cmlteam.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import static com.cmlteam.web.LogRestRequestWebInterceptorConfiguration.LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED;
 
 @Configuration
 @ConditionalOnProperty(value = LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED)
-public class LogRestRequestWebInterceptorConfiguration extends WebMvcConfigurerAdapter {
+public class LogRestRequestWebInterceptorConfiguration implements WebMvcConfigurer {
 
   static final String LOG_REQUEST_WEB_INTERCEPTOR_PROPS = "logRestRequestWebInterceptor";
   static final String LOG_REQUEST_WEB_INTERCEPTOR_PROPS_ENABLED =
@@ -19,16 +18,6 @@ public class LogRestRequestWebInterceptorConfiguration extends WebMvcConfigurerA
 
   // In this case autowired in constructor doesn't work
   @Autowired private LogRestRequestWebInterceptor logRestRequestWebInterceptor;
-
-  @Bean
-  public LogRestRequestWebInterceptor logRestRequestWebInterceptor() {
-    return new LogRestRequestWebInterceptor();
-  }
-
-  @Bean
-  public LogRestRequestFilter logRestRequestFilter() {
-    return new LogRestRequestFilter();
-  }
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.cmlteam.web.LogRestRequestWebInterceptorConfiguration
+com.cmlteam.web.LogRestRequestWebInterceptorConfiguration,\
+com.cmlteam.web.AppConfiguration


### PR DESCRIPTION
As soon as Spring boot 2.6.2 prohibits circular dependencies by default, it's needed to add changes to this library